### PR TITLE
Include BasePath in isCurrentPath() check

### DIFF
--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -57,7 +57,7 @@ class TwigExtension extends \Twig_Extension
 
     public function isCurrentPath($name, $data = [])
     {
-        return $this->router->pathFor($name, $data) === $this->uri->getPath();
+        return $this->router->pathFor($name, $data) === $this->uri->getBasePath() . '/' . ltrim ( $this->uri->getPath() , '/');
     }
 
     /**


### PR DESCRIPTION
Fixes #75 because the subdirectory is now included on both ends of the check.